### PR TITLE
New colour scale component (intensity for now)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
   "editor.formatOnSave": true,
+  "eslint.format.enable": true,
+  "typescript.tsdk": "node_modules/typescript/lib",
   "workbench.tree.indent": 20
 }

--- a/src/ColourScales/ColourScale.tsx
+++ b/src/ColourScales/ColourScale.tsx
@@ -1,0 +1,97 @@
+import { makeStyles, Theme } from '@material-ui/core';
+import { uniq } from 'lodash';
+import React from 'react';
+import { InterpolateIntensityColor } from './ColourScaleHelper';
+import { ColourScaleProps } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({}));
+
+const ColourScale = ({
+  type = 'intensity',
+  mode = 'blocks',
+  intervals = [],
+  height = 24,
+  markers = true,
+  borderColour = 'transparent',
+}: ColourScaleProps) => {
+  const classes = useStyles();
+  let colours = [];
+
+  if (type === 'intensity') {
+    for (let i = 0; i < 100; i++) {
+      const fillColor = InterpolateIntensityColor((i + 1) / 100);
+
+      if (fillColor !== '#FFFFFF') {
+        colours.push(fillColor);
+      }
+    }
+  }
+
+  // Only unique
+  colours = uniq(colours);
+
+  if (intervals.length === 0) {
+    for (let i = 0; i < colours.length; i++) {
+      intervals.push((i / colours.length) * 10);
+    }
+  }
+
+  const markerStrip = markers && (
+    <div
+      style={{
+        width: '100%',
+        height: height,
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      {colours.map((c, index) => (
+        <div
+          key={index}
+          style={{ display: 'inline-block', flex: 1, textAlign: 'center', marginTop: 2, fontSize: '0.9em' }}
+        >
+          {intervals[index]}
+        </div>
+      ))}
+    </div>
+  );
+
+  if (mode === 'gradient') {
+    return (
+      <div>
+        <div
+          style={{
+            width: '100%',
+            height: height,
+            border: `solid 1px ${borderColour}`,
+            background: `linear-gradient(to right, ${colours.join(',')})`,
+          }}
+        ></div>
+        {markerStrip}
+      </div>
+    );
+  }
+  if (mode === 'blocks')
+    return (
+      <div>
+        <div
+          style={{
+            width: '100%',
+            height: height,
+            border: `solid 1px ${borderColour}`,
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          {colours.map((c, index) => (
+            <div key={index} style={{ display: 'inline-block', flex: 1, background: c }}></div>
+          ))}
+        </div>
+        {markerStrip}
+      </div>
+    );
+
+  return <></>;
+};
+
+export default ColourScale;

--- a/src/ColourScales/ColourScaleHelper.tsx
+++ b/src/ColourScales/ColourScaleHelper.tsx
@@ -1,0 +1,43 @@
+export const InterpolateIntensityColor = (weight: number) => {
+  const hexes = [
+    '#800080',
+    '#5500ab',
+    '#2a00d5',
+    '#0000ff',
+    '#0038e1',
+    '#006fc3',
+    '#00a6a6',
+    '#00c46e',
+    '#00e237',
+    '#00ff00',
+    '#55ff00',
+    '#aaff00',
+    '#ffff00',
+    '#ffaa00',
+    '#ff5500',
+    '#ff0000',
+  ];
+  const rgbs: number[][] = [];
+
+  for (const hex of hexes) {
+    const bigint = parseInt(hex.replace('#', ''), 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+
+    rgbs.push([r, g, b]);
+  }
+
+  for (let i = 0; i < hexes.length; i++) {
+    const percentage = (i + 1) / hexes.length;
+    const nextPercentage = (i + 2) / hexes.length;
+
+    if (weight >= percentage && weight < nextPercentage) {
+      const rgb = rgbs[i];
+
+      return `#${((1 << 24) + (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]).toString(16).slice(1)}`;
+    }
+  }
+
+  return '#FFFFFF';
+};

--- a/src/ColourScales/ColourScales.stories.tsx
+++ b/src/ColourScales/ColourScales.stories.tsx
@@ -1,0 +1,15 @@
+import { withKnobs } from '@storybook/addon-knobs';
+import React from 'react';
+import ColourScale from './ColourScale';
+
+export default {
+  title: 'Colour Scale Components',
+  component: [ColourScale],
+  decorators: [withKnobs],
+};
+
+export const ColourScalesStory = () => {
+  return (
+    <ColourScale type="intensity" mode="blocks" intervals={[]} height={24} markers={true} borderColour="transparent" />
+  );
+};

--- a/src/ColourScales/types.ts
+++ b/src/ColourScales/types.ts
@@ -1,0 +1,10 @@
+interface ColourScaleProps {
+  type?: 'intensity';
+  mode?: 'blocks' | 'gradient';
+  intervals?: number[];
+  height?: number;
+  markers?: boolean;
+  borderColour?: string;
+}
+
+export { ColourScaleProps };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,12 @@
+export * from './Accounts/Accounts';
 export { default } from './Auth/AuthService';
 export * from './Auth/Login/Login';
 export * from './Auth/Login/types';
 export * from './Auth/LoginGate';
-export * from './Accounts/Accounts';
+export * from './ColourScales/ColourScale';
+export * from './ColourScales/ColourScaleHelper';
+export * from './ColourScales/types';
 export * from './common/Metadata/Metadata';
-export * from './UserGroups/UserGroups';
 export * from './DataServices/DataServices';
 export * from './DataServices/types';
 export * from './Jobs/JobList/JobList';
@@ -23,4 +25,6 @@ export * from './Scenarios/types';
 export * from './Timeseries/ChartPlotly/ChartPlotly';
 export * from './Timeseries/ChartPlotly/types';
 export * from './Timeseries/TimeseriesExporter/TimeseriesExporter';
+export * from './UserGroups/UserGroups';
 export * from './utils/Utils';
+


### PR DESCRIPTION
Can run in two modes (`blocks`, `gradient`) with one mode for now `intensity` with overridable interval numerics.

![image](https://user-images.githubusercontent.com/107109/96418721-8b53f000-1236-11eb-8bff-8784f1c62197.png)

![image](https://user-images.githubusercontent.com/107109/96418752-960e8500-1236-11eb-88ea-28e48588d0d9.png)
