### PR TITLE
fix(lab): index exports

### DIFF
--- a/packages/react-components-lab/docs/CONTRIBUTING.md
+++ b/packages/react-components-lab/docs/CONTRIBUTING.md
@@ -78,6 +78,12 @@ The `peerDependencies` are the dependencies that the developers using our packag
 
 While developing, we are primarily using the `devDependencies` to develop the library. Any dependencies that are needed for the development should be added here.
 
+## Exporting
+Components and all other consumable files should be exported in `src/index.ts`  
+If the file has a **default export**, use the following syntax: `export { default as ComponentName } from 'src/components/ComponentName/ComponentName';`  
+If the file has one or more **named exports**, use the following syntax `export * from 'src/components/ComponentName/ComponentName';`  
+If the file contains both a **default** and **named** exports, use both of the above.  
+
 ## Testing
 
 - to be added

--- a/packages/react-components-lab/src/components/Legend/styles.ts
+++ b/packages/react-components-lab/src/components/Legend/styles.ts
@@ -34,5 +34,4 @@ const LegendStyles = makeStyles(() => ({
   },
 }));
 
-export { LegendStyles };
 export default LegendStyles;

--- a/packages/react-components-lab/src/components/Snackbar/styles.ts
+++ b/packages/react-components-lab/src/components/Snackbar/styles.ts
@@ -32,5 +32,4 @@ const SnackbarStyles = makeStyles(() => ({
   },
 }));
 
-export { SnackbarStyles };
 export default SnackbarStyles;

--- a/packages/react-components-lab/src/index.ts
+++ b/packages/react-components-lab/src/index.ts
@@ -1,9 +1,15 @@
+// Legend
+export { default as Legend } from './components/Legend/Legend';
 export * from './components/Legend/Legend';
-export * from './components/Legend/styles';
+export { default as LegendStyles } from './components/Legend/styles';
 export * from './components/Legend/types';
+
+// Snackbar
 export { default as SnackbarProvider } from './components/Snackbar/SnackbarProvider';
 export { default as useSnackbar } from './components/Snackbar/useSnackbar';
-export * from './components/Snackbar/styles';
+export { default as SnackbarStyles } from './components/Snackbar/styles';
 export * from './components/Snackbar/types';
+
+// ThemeProvider
 export { default as ThemeProvider } from './components/ThemeProvider/ThemeProvider';
 export * from './components/ThemeProvider/types';


### PR DESCRIPTION

- [x] Fixes and closes #98

According to the airbnb eslint-config components must be *default* exported, meaning that the syntax is different for named and default exports in the `src/index.ts` file.

See the changed CONTRIBUTING.md for more 