### PR TITLE
Use ThemeOptions instead of overrides props

### DIFF
--- a/packages/react-components-lab/src/components/ThemeProvider/types.ts
+++ b/packages/react-components-lab/src/components/ThemeProvider/types.ts
@@ -4,7 +4,7 @@ import { Palette, PaletteColor } from '@material-ui/core/styles/createPalette';
 import { Overrides } from '@material-ui/core/styles/overrides';
 
 export interface IProps {
-  overrides?: Overrides;
+  overrides?: ThemeOptions;
   children?: ReactNode;
 }
 


### PR DESCRIPTION
## This PR

- [x ] Use ThemeOptions props instead of Overrides in ThemeProvider IProps.
Close #129 

### Completness

this way, typescript will know what options we want to be overrided.
