### PR TITLE
Redesign board of maintainers section layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,35 +27,35 @@ Please also check out the guidelines for the package you are contributing to.
 ## Board of maintainers
 
 <table>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/goneale"><img src="https://avatars.githubusercontent.com/goneale" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Graham O'Neale (gron)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+  <tr style="border: none">
+  	<td align="center" style="border: none">
+    	<a href="https://github.com/goneale"><img src="https://avatars.githubusercontent.com/goneale" width="70px" style="border-radius: 50%" /><br /><sub><b>Graham O'Neale (gron)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/elbys"><img src="https://avatars.githubusercontent.com/elbys" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Elbys Jose Meneses (ejme)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+      <a href="https://github.com/elbys"><img src="https://avatars.githubusercontent.com/elbys" width="70px" style="border-radius: 50%" /><br /><sub><b>Elbys Jose Meneses (ejme)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/rihr"><img src="https://avatars.githubusercontent.com/rihr" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Rihards Rancans (rira)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/rihr"><img src="https://avatars.githubusercontent.com/rihr" width="70px" style="border-radius: 50%" /><br /><sub><b>Rihards Rancans (rira)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/bertearazvan"><img src="https://avatars.githubusercontent.com/bertearazvan" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Razvan Bertea (rabe)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/bertearazvan"><img src="https://avatars.githubusercontent.com/bertearazvan" width="70px" style="border-radius: 50%" /><br /><sub><b>Razvan Bertea (rabe)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/nfour"><img src="https://avatars.githubusercontent.com/nfour" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Sam Johnson (sajo)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/nfour"><img src="https://avatars.githubusercontent.com/nfour" width="70px" style="border-radius: 50%" /><br /><sub><b>Sam Johnson (sajo)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/jharper93"><img src="https://avatars.githubusercontent.com/jharper93" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>James Harper (jamh)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/jharper93"><img src="https://avatars.githubusercontent.com/jharper93" width="70px" style="border-radius: 50%" /><br /><sub><b>James Harper (jamh)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
   </tr>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/FranzThomsen1089"><img src="https://avatars.githubusercontent.com/FranzThomsen1089" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Franz Thomsen (frt)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+  <tr style="border: none;">
+    <td align="center" style="border: none">
+      <a href="https://github.com/FranzThomsen1089"><img src="https://avatars.githubusercontent.com/FranzThomsen1089" width="70px" style="border-radius: 50%" /><br /><sub><b>Franz Thomsen (frt)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/rosudhi"><img src="https://avatars.githubusercontent.com/rosudhi" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Ronald Sutantio (rosu)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/rosudhi"><img src="https://avatars.githubusercontent.com/rosudhi" width="70px" style="border-radius: 50%" /><br /><sub><b>Ronald Sutantio (rosu)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
-    <td align="center">
-      <a href="https://github.com/j08lue"><img src="https://avatars.githubusercontent.com/j08lue" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Jonas Sølvsteen (josl)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    <td align="center" style="border: none">
+    	<a href="https://github.com/j08lue"><img src="https://avatars.githubusercontent.com/j08lue" width="70px" style="border-radius: 50%" /><br /><sub><b>Jonas Sølvsteen (josl)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -26,10 +26,36 @@ Please also check out the guidelines for the package you are contributing to.
 
 ## Board of maintainers
 
-- Graham O'Neale (gron)
-- Elbys Jose Meneses (ejme)
-- Rihards Rancans (rira)
-- Razvan Bertea (rabe)
-- Sam Johnson (sajo)
-- James Harper (jamh)
-- Franz Thomsen (frt)
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/goneale"><img src="https://avatars.githubusercontent.com/goneale" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Graham O'Neale (gron)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/elbys"><img src="https://avatars.githubusercontent.com/elbys" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Elbys Jose Meneses (ejme)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/rihr"><img src="https://avatars.githubusercontent.com/rihr" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Rihards Rancans (rira)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/bertearazvan"><img src="https://avatars.githubusercontent.com/bertearazvan" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Razvan Bertea (rabe)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/nfour"><img src="https://avatars.githubusercontent.com/nfour" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Sam Johnson (sajo)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/jharper93"><img src="https://avatars.githubusercontent.com/jharper93" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>James Harper (jamh)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/FranzThomsen1089"><img src="https://avatars.githubusercontent.com/FranzThomsen1089" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Franz Thomsen (frt)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/rosudhi"><img src="https://avatars.githubusercontent.com/rosudhi" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Ronald Sutantio (rosu)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+    <td align="center">
+      <a href="https://github.com/j08lue"><img src="https://avatars.githubusercontent.com/j08lue" width="70px;" alt="" style="border-radius:50%" /><br /><sub><b>Jonas Sølvsteen (josl)</b></sub></a><br /><span title="Coder">💻</span><span title="Documenter">📖</span><span title="Tester">🧪</span><span title="Designer">🎨</span><span title="Bug Reporter">🐛</span>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## This PR Close #104

- [x] Add 2 members to `Board of maintainers` section
- [x] Proposal to have new layout design of `Board of maintainers`

I just add all of rules icon that may applied, feel free to remove or add new one. Icon title will appear as a tooltip.
* the icons took from WhatsApp icons.

Screenshot
![image](https://user-images.githubusercontent.com/46663012/121537395-16842f00-ca2e-11eb-9de5-2edc936ab18b.png)
