### PR TITLE
Add optional initialValue

### DIFF
--- a/packages/react-components-lab/src/hooks/useLocalStorage/types.ts
+++ b/packages/react-components-lab/src/hooks/useLocalStorage/types.ts
@@ -1,4 +1,4 @@
 export interface HookTypes {
-  initialValue: unknown;
   key: string;
+  initialValue?: unknown;
 }


### PR DESCRIPTION
Fixes bug related to initialValue variable - on initialization there might be cases when setting a key value pair is not needed.
