### PR TITLE
fix(lab):add generic to useLocalStorage

### DIFF
--- a/packages/react-components-lab/src/hooks/useLocalStorage.ts
+++ b/packages/react-components-lab/src/hooks/useLocalStorage.ts
@@ -1,20 +1,21 @@
 import { useState } from 'react';
-import { HookTypes } from './types';
 
-export default ({
-  key,
-  initialValue,
-}: HookTypes): [unknown, (value: unknown) => void] => {
+function useLocalStorage<T>(
+  key: string,
+  initialValue?: T
+): [T, (value: T) => void] {
   const [storageValue, setStorageValue] = useState(() => {
     const item = window.localStorage.getItem(key);
 
-    return item ? String(JSON.parse(item)) : initialValue;
+    return item ? ((String(JSON.parse(item)) as unknown) as T) : initialValue;
   });
 
-  const setValue = (value: unknown) => {
+  const setValue = (value: T) => {
     setStorageValue(value);
     window.localStorage.setItem(key, JSON.stringify(value));
   };
 
   return [storageValue, setValue];
-};
+}
+
+export default useLocalStorage;

--- a/packages/react-components-lab/src/hooks/useLocalStorage.ts
+++ b/packages/react-components-lab/src/hooks/useLocalStorage.ts
@@ -7,7 +7,7 @@ function useLocalStorage<T>(
   const [storageValue, setStorageValue] = useState(() => {
     const item = window.localStorage.getItem(key);
 
-    return item ? ((String(JSON.parse(item)) as unknown) as T) : initialValue;
+    return item ? (JSON.parse(item) as T) : initialValue;
   });
 
   const setValue = (value: T) => {

--- a/packages/react-components-lab/src/hooks/useLocalStorage/types.ts
+++ b/packages/react-components-lab/src/hooks/useLocalStorage/types.ts
@@ -1,4 +1,0 @@
-export interface HookTypes {
-  key: string;
-  initialValue?: unknown;
-}

--- a/packages/react-components-lab/src/index.ts
+++ b/packages/react-components-lab/src/index.ts
@@ -31,5 +31,4 @@ export * from './components/ThemeProvider/types';
 
 // Hooks
 export { default as useBelow } from './hooks/useBelow';
-export { default as useLocalStorage } from './hooks/useLocalStorage/useLocalStorage';
-export * from './hooks/useLocalStorage/types';
+export { default as useLocalStorage } from './hooks/useLocalStorage';


### PR DESCRIPTION
Changes useLocalStorage to use generic type and to use key and default value as params instead of object