### PR TITLE
fix(Card): Enhance styling for the card

### DIFF
--- a/packages/react-components-lab/src/components/Card/Card.tsx
+++ b/packages/react-components-lab/src/components/Card/Card.tsx
@@ -38,9 +38,16 @@ const Card: FC<CardProps> = ({
           justifyContent="space-between"
         >
           <Box display="flex" flexDirection="column" justifyContent="center">
-            <Typography variant="h5" className={classes.title}>
+            <Typography
+              variant="h5"
+              className={clsx(
+                !isClickable && classes.titlePaddingNonClickable,
+                classes.title
+              )}
+            >
               {title}
             </Typography>
+
             {subTitle && (
               <Typography variant="subtitle1" className={classes.subTitle}>
                 {subTitle}

--- a/packages/react-components-lab/src/components/Card/styles.ts
+++ b/packages/react-components-lab/src/components/Card/styles.ts
@@ -23,8 +23,8 @@ export default makeStyles<IMikeTheme>((theme) => ({
     opacity: 0.7,
   },
   title: {
-    paddingTop: 4,
-    paddingBottom: 4,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
   },
   subTitle: {
     fontSize: 12,
@@ -43,7 +43,7 @@ export default makeStyles<IMikeTheme>((theme) => ({
     height: 'auto',
   },
   titlePaddingNonClickable: {
-    paddingTop: 4,
-    paddingBottom: 4,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
   },
 }));

--- a/packages/react-components-lab/src/components/Card/styles.ts
+++ b/packages/react-components-lab/src/components/Card/styles.ts
@@ -23,8 +23,8 @@ export default makeStyles<IMikeTheme>((theme) => ({
     opacity: 0.7,
   },
   title: {
-    fontSize: 14,
-    fontWeight: 500,
+    paddingTop: 4,
+    paddingBottom: 4,
   },
   subTitle: {
     fontSize: 12,
@@ -41,5 +41,9 @@ export default makeStyles<IMikeTheme>((theme) => ({
   image: {
     width: '90%',
     height: 'auto',
+  },
+  titlePaddingNonClickable: {
+    paddingTop: 4,
+    paddingBottom: 4,
   },
 }));

--- a/packages/react-components-lab/src/components/Card/types.ts
+++ b/packages/react-components-lab/src/components/Card/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 export interface CardProps {
-  title: string;
+  title: string | ReactNode;
   description?: string[] | string | ReactNode;
   isOpen?: boolean;
   subTitle?: string | null;


### PR DESCRIPTION
Enhances the Card component styling.

See in the screenshot that the title is inconsistent if `isClickable={false}`. Moreover allows for the `ReactNode` type for the title