### PR TITLE
Fix Missing Deckgl Types

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -31,7 +31,6 @@
   "module": "dist/react-components.esm.js",
   "devDependencies": {
     "@babel/core": "^7.9.6",
-    "@danmarshall/deckgl-typings": "^4.9.7",
     "@storybook/addon-actions": "^6.3.12",
     "@storybook/addon-docs": "^6.3.12",
     "@storybook/addon-info": "^5.3.21",
@@ -72,6 +71,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@danmarshall/deckgl-typings": "^4.9.7",
     "@date-io/date-fns": "^1.3.9",
     "@devexpress/dx-react-core": "^2.7.3",
     "@devexpress/dx-react-grid": "^2.7.3",

--- a/packages/react-components/src/Maps/index.ts
+++ b/packages/react-components/src/Maps/index.ts
@@ -8,7 +8,6 @@ import {
   getVesselGeometry,
   shipTypeIdToName,
 } from './AisVesselLayer/vesselsToMapFeature';
-export * from './AisVesselLayer/types';
 export * from './AisVesselLayer/AisFilterMenu/types';
 export * from './AisVesselLayer/types';
 export {


### PR DESCRIPTION
* AisLayer was missing some required DeckGL types, causing it to expect 0 arguments when used in projects.