### PR TITLE
Add docs for yarnrc.yml and publishing

### DIFF
--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -18,15 +18,18 @@ Generating a Personal Access token with GitHub - [More info](https://help.github
 6. Tick: `repo, write:packages, read:packages, delete:packages, admin:repo_hook`
 7. "Generate token"
 8. Click clipboard icon to copy token.
-9. Open `C:\users\<username>\.npmrc` or create this file here if doesn't exist.
+9. Open `C:\users\<username>\.yarnrc.yml` or create this file here if doesn't exist.
 10. Paste within it, replacing `<AUTH_TOKEN>` with the token you copied moments ago.
 
 ```
-@dhi:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=<AUTH_TOKEN>
+npmScopes:
+  dhi:
+    npmAlwaysAuth: true
+    npmAuthToken: <AUTH_TOKEN>
+    npmRegistryServer: "https://npm.pkg.github.com"
 ```
 
-<sup>(this file can also be created in project-scope via `.npmrc` in root, but it is not advised as it links to your personal access token.)</sup>
+<sup>(this file can also be created in project-scope via `.yarnrc.yml` in root, but it is not advised as it links to your personal access token.)</sup>
 
 11. Now you may install DHI packages from GitHub Packages!
 
@@ -74,3 +77,15 @@ project> yalc add @dhi/react-components
 Every time you make a change to the react-component, just re-run `yalc push` and it will auto-update working project!
 
 _Note_ Once you have completed your development, ensure you `yalc remove @dhi/react-components` publish the package to the web and run `yarn add react-components` to ensure you've wired up to the production (public) package.
+
+
+## Publishing the package
+
+Publishing the package can be done by running the following command in the root of the package "react-components". 
+
+```
+yarn npm publish
+```
+
+**Note:** There is no prompt for the package version. The version to be published will be found in `./packages/react-components/package.json`.
+


### PR DESCRIPTION
## This PR

Closes #248

## Notes

- It updates the specs where the GitHub token should be placed.
- Updates the docs with the command used for publishing the package.
