### PR TITLE
Option to show year in ScenarioList

### DIFF
--- a/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
+++ b/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
@@ -33,6 +33,7 @@ const ScenarioList = (props: ScenarioListProps) => {
     showMenu,
     timeZone,
     multipleSelection,
+    showYear,
   } = props;
   const [groupedScenarios, setGroupedScenarios] = useState<Dictionary<Scenario[]>>();
   const classes = useStyles();
@@ -118,19 +119,20 @@ const ScenarioList = (props: ScenarioListProps) => {
       });
   };
 
-  const buildDateArea = (date: string) => {
+  const buildDateArea = (date: string, showYear: boolean) => {
     const isoDate = timeZone ? utcToTz(date, timeZone) : parseISO(date);
     const dateObject = {
       day: format(isoDate, 'dd'),
       dayName: format(isoDate, 'EEEE'),
       monthName: format(isoDate, 'MMM'),
+      year: format(isoDate, 'yyyy'),
     };
 
     return (
       <div className={classes.dateBlock}>
         <div className={classes.dateArea}>
           <strong>
-            {`${dateObject.day} ${dateObject.monthName}`} <span>{` - ${dateObject.dayName}`} </span>
+            {showYear ? `${dateObject.day} ${dateObject.monthName} ${dateObject.year}` : `${dateObject.day} ${dateObject.monthName}`}  <span>{` - ${dateObject.dayName}`} </span>
           </strong>
         </div>
       </div>
@@ -168,7 +170,7 @@ const ScenarioList = (props: ScenarioListProps) => {
       .map((key, index) => {
         return (
           <div key={key} className={classes.listBlock}>
-            {showDateGroups && key && buildDateArea(key)}
+            {showDateGroups && key && buildDateArea(key, showYear)}
             <div>{key && buildScenariosList(groupedScenarios[key])}</div>
           </div>
         );

--- a/packages/react-components/src/Scenarios/ScenarioList/types.ts
+++ b/packages/react-components/src/Scenarios/ScenarioList/types.ts
@@ -44,7 +44,7 @@ interface ScenarioListProps {
   /**
    * Indicates if the year of the scenario should be shown
    */
-   showYear: boolean;
+  showYear?: boolean;
   /**
    * Indicates if the date groups of the scenario list should be shown
    */

--- a/packages/react-components/src/Scenarios/ScenarioList/types.ts
+++ b/packages/react-components/src/Scenarios/ScenarioList/types.ts
@@ -42,6 +42,10 @@ interface ScenarioListProps {
    */
   showDate: boolean;
   /**
+   * Indicates if the year of the scenario should be shown
+   */
+   showYear: boolean;
+  /**
    * Indicates if the date groups of the scenario list should be shown
    */
   showDateGroups?: boolean;

--- a/packages/react-components/src/Scenarios/Scenarios.stories.tsx
+++ b/packages/react-components/src/Scenarios/Scenarios.stories.tsx
@@ -422,7 +422,7 @@ export const ScenariosJSONStory = () => {
               }}
               // actionButton={actionButton}
               showDate={true}
-              showYear={false}
+              showYear
               showDateGroups={true}
               showHour
               showMenu

--- a/packages/react-components/src/Scenarios/Scenarios.stories.tsx
+++ b/packages/react-components/src/Scenarios/Scenarios.stories.tsx
@@ -422,6 +422,7 @@ export const ScenariosJSONStory = () => {
               }}
               // actionButton={actionButton}
               showDate={true}
+              showYear={false}
               showDateGroups={true}
               showHour
               showMenu

--- a/packages/react-components/src/Scenarios/Scenarios/Scenarios.tsx
+++ b/packages/react-components/src/Scenarios/Scenarios/Scenarios.tsx
@@ -46,6 +46,7 @@ const Scenarios = (props: ScenariosProps) => {
     showEditButton,
     selectedScenarioId,
     showDate = true,
+    showYear = false,
     showDateGroups = true,
     showHour,
     showMenu,
@@ -645,6 +646,7 @@ const Scenarios = (props: ScenariosProps) => {
           onRenderScenarioIcon={onRenderScenarioIcon}
           onRowRefsUpdated={onRowRefsUpdated}
           showDate={showDate}
+          showYear={showYear}
           showDateGroups={showDateGroups}
           showHour={showHour}
           showMenu={showMenu}

--- a/packages/react-components/src/Scenarios/Scenarios/types.ts
+++ b/packages/react-components/src/Scenarios/Scenarios/types.ts
@@ -13,7 +13,7 @@ interface ScenariosProps {
   /**
    * Indicates if the year of the scenario should be shown
    */
-   showYear: boolean;
+  showYear?: boolean;
   /**
    * Indicates if the date groups of the scenario list should be shown
    */

--- a/packages/react-components/src/Scenarios/Scenarios/types.ts
+++ b/packages/react-components/src/Scenarios/Scenarios/types.ts
@@ -11,6 +11,10 @@ interface ScenariosProps {
    */
   showDate: boolean;
   /**
+   * Indicates if the year of the scenario should be shown
+   */
+   showYear: boolean;
+  /**
    * Indicates if the date groups of the scenario list should be shown
    */
   showDateGroups?: boolean;


### PR DESCRIPTION
## This PR

Adding showYear to the Scenarios component will add the Year in ScenarioList. 

The default value is "false".


## Notes

This issue comes from https://sopx.atlassian.net/browse/PS-127

![image](https://user-images.githubusercontent.com/65273849/168526680-07e632fc-e76b-4ccb-bc55-86698b44ecb4.png)

### Fulfilled the scope of this repo?

- [ ] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [ ] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
