### PR TITLE
Toggle ScenarioListOLD when scenarioSelectedID prop change

### DIFF
--- a/packages/react-components/src/Scenarios/ScenarioListOLD/ScenarioList.tsx
+++ b/packages/react-components/src/Scenarios/ScenarioListOLD/ScenarioList.tsx
@@ -32,6 +32,10 @@ const ScenarioListOLD = (props: ScenarioListOLDProps) => {
   useEffect(() => {
     groupScenarios(scenarios);
   }, [scenarios]);
+  
+  useEffect(() => {
+    setSelectedId(selectedScenarioId);
+  }, [selectedScenarioId]);
 
   const groupScenarios = (scenarios: ScenarioOLD[]) => {
     setGroupedScenarios(


### PR DESCRIPTION
## This PR

Closes #xxx

## Notes

_This issue is part of https://sopx.atlassian.net/browse/CI-1209_

This new feature in MA enables users to select a different scenario by clicking on vessels on the map. 

**Currently is not possible to change the scenario selected "in grey" to what is displayed on the map due to the new feature.** 

![image](https://user-images.githubusercontent.com/65273849/183574679-803fef9f-2a3f-40c5-889c-4401d0bfdd97.png)

Adding this change should fix the issue

### Fulfilled the scope of this repo?

- [x] The exact functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [x] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
