### PR TITLE
Option to check for job status

### DIFF
--- a/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
+++ b/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
@@ -34,7 +34,7 @@ const ScenarioList = (props: ScenarioListProps) => {
     timeZone,
     multipleSelection,
     showYear,
-    checkJobStatus
+    checkJobStatus = true
   } = props;
   const [groupedScenarios, setGroupedScenarios] = useState<Dictionary<Scenario[]>>();
   const classes = useStyles();

--- a/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
+++ b/packages/react-components/src/Scenarios/ScenarioList/ScenarioList.tsx
@@ -34,6 +34,7 @@ const ScenarioList = (props: ScenarioListProps) => {
     timeZone,
     multipleSelection,
     showYear,
+    checkJobStatus
   } = props;
   const [groupedScenarios, setGroupedScenarios] = useState<Dictionary<Scenario[]>>();
   const classes = useStyles();
@@ -79,7 +80,11 @@ const ScenarioList = (props: ScenarioListProps) => {
     return sortBy(scenarioGroup, ['dateTime'])
       .reverse()
       .map((scenario, index) => {
-        const itemStatus = checkStatus(scenario.lastJob, status);
+        const itemStatus = checkJobStatus ? checkStatus(scenario.lastJob, status) : { 
+          name: 'Completed',
+          color: '#81C784',
+          message: 'Completed',
+        };
 
         return (
           <div

--- a/packages/react-components/src/Scenarios/ScenarioList/types.ts
+++ b/packages/react-components/src/Scenarios/ScenarioList/types.ts
@@ -100,6 +100,10 @@ interface ScenarioListProps {
    * Allow user to select multiple scenarios
    */
   multipleSelection?: boolean;
+  /**
+   * Check if Jobs need to be considered
+   */
+  checkJobStatus?: boolean;
 }
 
 export default ScenarioListProps;

--- a/packages/react-components/src/Scenarios/Scenarios/Scenarios.tsx
+++ b/packages/react-components/src/Scenarios/Scenarios/Scenarios.tsx
@@ -65,6 +65,7 @@ const Scenarios = (props: ScenariosProps) => {
     translations,
     timeZone,
     debug,
+    checkJobStatus = true
   } = props;
 
   const [dialog, setDialog] = useState<GeneralDialogProps>({
@@ -666,6 +667,7 @@ const Scenarios = (props: ScenariosProps) => {
           actionButton={actionButton}
           showReportButton={showReportButton}
           showEditButton={showEditButton}
+          checkJobStatus={checkJobStatus}
         />
       )}
       {dialog && (

--- a/packages/react-components/src/Scenarios/Scenarios/types.ts
+++ b/packages/react-components/src/Scenarios/Scenarios/types.ts
@@ -216,6 +216,10 @@ interface ScenariosProps {
    * SignalR connection hub URL.
    */
   signalRConnectionHubUrl: string;
+  /**
+   * Check if Jobs need to be considered
+   */
+  checkJobStatus?: boolean;
 }
 
 interface QueryBody {


### PR DESCRIPTION
## This PR

There are cases that there's no need to run through jobs to retrieve the status of a scenario. Hence, the option checkJobStatus added to Scenarios component. 

Default value is true. For those that don't need this option enabled.

### Fulfilled the scope of this repo?

- [ ] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [ ] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
