### PR TITLE
Fix bar legend having duplicate keys resulting in the bar legend range getting bigger and bigger if duplicates occurred

### DIFF
--- a/packages/react-components-lab/package.json
+++ b/packages/react-components-lab/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@dhi/react-components-lab",

--- a/packages/react-components-lab/src/components/BarLegend/BarLegend.tsx
+++ b/packages/react-components-lab/src/components/BarLegend/BarLegend.tsx
@@ -6,6 +6,7 @@ import ImgLegendStyled from './ImgLegend.styled';
 const BarLegend: FC<BarLegendProps> = ({ src, length, range, unit = '' }) => {
   const [val, setVals] = useState<number[] | undefined>();
   const theme = useTheme();
+
   useEffect(() => {
     if (
       length !== undefined &&
@@ -34,8 +35,9 @@ const BarLegend: FC<BarLegendProps> = ({ src, length, range, unit = '' }) => {
       {range &&
         (typeof range[0] === 'number' && typeof range[1] === 'number' && val ? (
           <Box display="flex" justifyContent="space-between">
-            {val.map((v: number) => (
-              <Typography key={`value-${v}`} sx={{ fontSize: 10 }}>
+            {val.map((v: number, index: number) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Typography key={index} sx={{ fontSize: 10 }}>
                 {`${v} ${unit}`}
               </Typography>
             ))}


### PR DESCRIPTION
## This PR

fixes the bar legend if duplicates were to occur in the range

Closes [#59118](https://dhigroup.visualstudio.com/DnA/_workitems/edit/59118)

## Notes

- No notes to add

### Fulfilled the scope of this repo?

- [x] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [ ] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
