### PR TITLE
Feat/static legend improvements

### DIFF
--- a/packages/react-components-lab/package.json
+++ b/packages/react-components-lab/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@dhi/react-components-lab",

--- a/packages/react-components-lab/src/components/LegendBase/ButtonBase.styled.ts
+++ b/packages/react-components-lab/src/components/LegendBase/ButtonBase.styled.ts
@@ -6,7 +6,7 @@ export default styled(ButtonBase)(({ theme }) => ({
   height: theme.spacing(5),
   display: 'flex',
   gap: theme.spacing(1),
-  justifyContent: 'flex-end',
+  justifyContent: 'space-between',
   '&.MuiButtonBase-root': {
     background: theme.palette.background.default,
     padding: theme.spacing(1),

--- a/packages/react-components-lab/src/components/LegendBase/TruncateTypography.styled.ts
+++ b/packages/react-components-lab/src/components/LegendBase/TruncateTypography.styled.ts
@@ -5,5 +5,4 @@ export default styled(Typography)({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  maxWidth: 75,
 });

--- a/packages/react-components-lab/src/components/StaticLegend/StaticLegend.tsx
+++ b/packages/react-components-lab/src/components/StaticLegend/StaticLegend.tsx
@@ -12,6 +12,7 @@ const StaticLegend: FC<StaticLegendProps> = ({
   position = 'bottomRight',
   defaultCollapsed = false,
   collapsable = false,
+  sx,
 }) => (
   <LegendBase
     unit={unit}
@@ -19,6 +20,7 @@ const StaticLegend: FC<StaticLegendProps> = ({
     position={position}
     collapsable={collapsable}
     defaultCollapsed={defaultCollapsed}
+    sx={sx}
   >
     {items.map((item, i) => (
       <Box
@@ -32,7 +34,7 @@ const StaticLegend: FC<StaticLegendProps> = ({
           {item.label}
         </TruncateTypographyStyled>
 
-        <ColorBoxStyled sx={{ backgroundColor: item.color }} />
+        <ColorBoxStyled sx={{ backgroundColor: item.color, flexShrink: 0 }} />
       </Box>
     ))}
   </LegendBase>

--- a/packages/react-components-lab/src/components/StaticLegend/types.ts
+++ b/packages/react-components-lab/src/components/StaticLegend/types.ts
@@ -1,3 +1,5 @@
+import { SxProps } from '@mui/system';
+import { Theme } from '@mui/material';
 import { LegendBaseProps } from '../LegendBase/types';
 
 export interface StaticLegendItem {
@@ -6,4 +8,5 @@ export interface StaticLegendItem {
 }
 export interface StaticLegendProps extends Omit<LegendBaseProps, 'children'> {
   items: StaticLegendItem[];
+  sx?: SxProps<Theme> | undefined;
 }


### PR DESCRIPTION
## This PR

- updates the static legend to take in sx prop
- prevents color element in static legend to be shrunk
- uses space between instead of flex-end for the title (image below)
- remove the hard maxwidth, as it's rather restricting and should be decided on a use-case basis

When the legend became large enough, this would happen to the title (this happens with the default 150 size too)
![image](https://user-images.githubusercontent.com/74733800/218731542-c6396efe-302e-4ee6-a85a-2416a0560805.png)

If the text became too long, it would go over the color: 
![image](https://user-images.githubusercontent.com/74733800/218731649-862a1569-a6e4-4327-99be-2e8e2afdea16.png)

This PR fixes both of those issues.

## Notes

- This could be considered a breaking change, as it removes the max-width size, but I don't think so?

### Fulfilled the scope of this repo?

- [x] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [x] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [x] Story included
