### PR TITLE
style that matches dark mode as well

### DIFF
--- a/packages/react-components-lab/package.json
+++ b/packages/react-components-lab/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.6",
+  "version": "2.2.7",
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@dhi/react-components-lab",

--- a/packages/react-components-lab/package.json
+++ b/packages/react-components-lab/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.^6",
+  "version": "2.2.6",
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@dhi/react-components-lab",

--- a/packages/react-components-lab/package.json
+++ b/packages/react-components-lab/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.6",
+  "version": "2.2.^6",
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@dhi/react-components-lab",

--- a/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
+++ b/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
@@ -12,8 +12,10 @@ const CollapsableBox: FC<CollapsableBoxProps> = ({
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const theme = useTheme();
-  const gradient = theme.palette.mode === 'light' ?  'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)' :  'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)'
-
+  const gradient =
+    theme.palette.mode === 'light'
+      ? 'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)'
+      : 'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)';
 
   return (
     <Box

--- a/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
+++ b/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
@@ -11,22 +11,9 @@ const CollapsableBox: FC<CollapsableBoxProps> = ({
   className = '',
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
-  const [gradient, setGradient] = useState(
-    'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)'
-  );
-
   const theme = useTheme();
-  useEffect(() => {
-    if (theme.palette.mode === 'light') {
-      setGradient(
-        'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)'
-      );
-    } else {
-      setGradient(
-        'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)'
-      );
-    }
-  }, [theme.palette.mode]);
+  const gradient = theme.palette.mode === 'light' ?  'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)' :  'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)'
+
 
   return (
     <Box

--- a/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
+++ b/packages/react-components-lab/src/components/CollapsableBox/CollapsableBox.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useState } from 'react';
-import { Box, Button, Collapse } from '@mui/material';
-import { ExpandMore } from '@mui/icons-material';
+import React, { FC, useEffect, useState } from 'react';
+import { Box, Button, Collapse, useTheme } from '@mui/material';
+import { ExpandLess } from '@mui/icons-material';
 import { CollapsableBoxProps } from './types';
 
 const CollapsableBox: FC<CollapsableBoxProps> = ({
@@ -11,9 +11,29 @@ const CollapsableBox: FC<CollapsableBoxProps> = ({
   className = '',
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [gradient, setGradient] = useState(
+    'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)'
+  );
+
+  const theme = useTheme();
+  useEffect(() => {
+    if (theme.palette.mode === 'light') {
+      setGradient(
+        'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)'
+      );
+    } else {
+      setGradient(
+        'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)'
+      );
+    }
+  }, [theme.palette.mode]);
 
   return (
-    <Box style={{ ...style }} className={className}>
+    <Box
+      style={{ ...style }}
+      className={className}
+      sx={{ backgroundColor: 'background.paper' }}
+    >
       <Collapse
         in={!isCollapsed}
         collapsedSize={75}
@@ -30,8 +50,7 @@ const CollapsableBox: FC<CollapsableBoxProps> = ({
             pointerEvents: 'none',
             width: '100%',
             bottom: 0,
-            background:
-              'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%)',
+            backgroundImage: gradient,
             height: isCollapsed && 50,
           }}
         />
@@ -48,7 +67,7 @@ const CollapsableBox: FC<CollapsableBoxProps> = ({
           }}
           fullWidth
         >
-          <ExpandMore
+          <ExpandLess
             sx={{
               transform: isCollapsed && 'rotateX(180deg)',
             }}


### PR DESCRIPTION


### Fulfilled the scope of this repo?

- [x] The CollapsableBox component is adaptable for both light and dark mode

### Completness

![Skærmbillede 2023-03-22 155300](https://user-images.githubusercontent.com/78146824/226944697-1de432f8-4896-4c30-b06f-8ce836340034.png)
![Skærmbillede 2023-03-22 155310](https://user-images.githubusercontent.com/78146824/226944707-f00a64b9-12c8-4833-abbb-3ef281eac7ab.png)
![Skærmbillede 2023-03-22 155234](https://user-images.githubusercontent.com/78146824/226944711-489885db-cf84-40af-86cd-a4657440bbbc.png)
![Skærmbillede 2023-03-22 155245](https://user-images.githubusercontent.com/78146824/226944717-303fb109-9c3b-453c-9954-778b0914002b.png)
