### PR TITLE
feat: add styling for value label for mui slider

### DIFF
--- a/packages/react-components-lab/src/components/ThemeProvider/getDhiOverrides.ts
+++ b/packages/react-components-lab/src/components/ThemeProvider/getDhiOverrides.ts
@@ -366,6 +366,14 @@ const getDhiOverrides = (mode: PaletteMode): Components => {
         },
       },
     },
+    MuiSlider: {
+      styleOverrides: {
+        valueLabel: {
+          backgroundColor: dhiPalette.grey[200],
+          color: dhiPalette.text.primary,
+        },
+      },
+    },
   };
 };
 


### PR DESCRIPTION
## This PR

Closes [65940](https://dhigroup.visualstudio.com/DnA/_backlogs/backlog/Engineering/Epics/?workitem=65940)

This now matches the tooltip coloring and supports dark theme now

## Notes

- No notes to add

### Fulfilled the scope of this repo?

- [ ] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [ ] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
