### PR TITLE
add input file components

### DIFF
--- a/packages/react-components-lab/src/components/InputFile/InputFile.stories.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFile.stories.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import { InputFileProps } from './types';
+import InputFile from './InputFile';
+
+export default {
+  title: 'Components/InputFile',
+  component: InputFile,
+  argTypes: {
+    variant: { control: 'select' },
+    accept: { control: 'string' },
+    quantity: { control: 'select' },
+    showFiles: { control: 'boolean' },
+  },
+} as Meta;
+
+const Template: Story<InputFileProps> = (args) => <InputFile {...args} />;
+
+export const Dropzone = Template.bind({});
+Dropzone.args = {
+  variant: 'dropzone',
+  accept: ['.txt', '.png'],
+  quantity: 'multiple',
+  showFiles: true,
+};
+
+export const DropzoneNoReplace = Template.bind({});
+DropzoneNoReplace.args = {
+  variant: 'dropzone',
+  accept: ['.txt', '.png'],
+  quantity: 'multiple',
+  showFiles: true,
+  replaceOnUpload: false,
+};
+
+export const DropzoneSingle = Template.bind({});
+DropzoneSingle.args = {
+  variant: 'dropzone',
+  accept: ['.txt', '.png'],
+  quantity: 'single',
+  showFiles: true,
+};
+
+export const DropzoneHiddenFiles = Template.bind({});
+DropzoneHiddenFiles.args = {
+  variant: 'dropzone',
+  accept: ['.txt', '.png'],
+  quantity: 'multiple',
+  showFiles: false,
+};
+
+export const Button = Template.bind({});
+Button.args = {
+  variant: 'button',
+  accept: ['.txt', '.png'],
+  quantity: 'multiple',
+  showFiles: true,
+};
+
+export const Icon = Template.bind({});
+Icon.args = {
+  variant: 'iconbutton',
+  accept: ['.txt', '.png'],
+  quantity: 'multiple',
+  showFiles: true,
+};

--- a/packages/react-components-lab/src/components/InputFile/InputFile.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFile.tsx
@@ -8,11 +8,22 @@ import InputFileIconButton from './InputFileIconButton';
 const InputFile: FC<InputFileProps> = (props) => {
   const [files, setFiles] = useState<File[]>([]);
 
-  const { variant, accept, onFilesRejected, onFilesUploaded, replaceOnUpload } =
-    props;
+  const {
+    variant,
+    accept,
+    quantity,
+    replaceOnUpload,
+    onFilesRejected,
+    onFilesUploaded,
+  } = props;
 
   const uploadFiles = (transferFiles: File[] | FileList) => {
     if (!transferFiles || !transferFiles.length) {
+      return;
+    }
+
+    if (quantity === 'single' && transferFiles.length > 1) {
+      onFilesRejected?.(Array.from<File>(transferFiles));
       return;
     }
 

--- a/packages/react-components-lab/src/components/InputFile/InputFile.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFile.tsx
@@ -1,0 +1,66 @@
+import React, { FC, useState } from 'react';
+import { InputFileProps } from './types';
+import { validateFiles } from './util';
+import InputFileDropzone from './InputFileDropzone';
+import InputFileButton from './InputFileButton';
+import InputFileIconButton from './InputFileIconButton';
+
+const InputFile: FC<InputFileProps> = (props) => {
+  const [files, setFiles] = useState<File[]>([]);
+
+  const { variant, accept, onFilesRejected, onFilesUploaded, replaceOnUpload } =
+    props;
+
+  const uploadFiles = (transferFiles: File[] | FileList) => {
+    if (!transferFiles || !transferFiles.length) {
+      return;
+    }
+
+    const [theFiles, rejectedFiles] = validateFiles(
+      Array.from<File>(transferFiles),
+      accept
+    );
+
+    if (rejectedFiles.length && onFilesRejected) {
+      onFilesRejected(rejectedFiles);
+    }
+
+    if (!theFiles.length) {
+      return;
+    }
+
+    if (replaceOnUpload) {
+      setFiles(theFiles);
+      onFilesUploaded?.(theFiles);
+      return;
+    }
+
+    setFiles((prevFiles) => {
+      const newFiles = [...prevFiles, ...theFiles];
+      onFilesUploaded?.(newFiles);
+      return newFiles;
+    });
+  };
+
+  const finalProps = {
+    uploadFiles,
+    files,
+    setFiles,
+    ...props,
+  };
+
+  return (
+    <>
+      {variant === 'dropzone' && <InputFileDropzone {...finalProps} />}
+      {variant === 'button' && <InputFileButton {...finalProps} />}
+      {variant === 'iconbutton' && <InputFileIconButton {...finalProps} />}
+    </>
+  );
+};
+
+InputFile.defaultProps = {
+  replaceOnUpload: true,
+  showFiles: true,
+};
+
+export default InputFile;

--- a/packages/react-components-lab/src/components/InputFile/InputFileBase.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFileBase.tsx
@@ -1,0 +1,35 @@
+import { Box } from '@mui/material';
+import React, { ChangeEvent, FC } from 'react';
+import { InputFileBaseProps, InputFileProps } from './types';
+
+const InputFileBase: FC<Partial<InputFileProps> & InputFileBaseProps> = ({
+  accept,
+  quantity,
+  handleFileChange,
+}) => {
+  let theAccept = '';
+
+  if (accept) {
+    if (Array.isArray(accept)) {
+      theAccept = accept.join(',');
+    } else {
+      theAccept = accept;
+    }
+  }
+
+  return (
+    <Box
+      accept={theAccept}
+      component="input"
+      multiple={quantity === 'multiple'}
+      sx={{ display: 'none' }}
+      type="file"
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        handleFileChange(e);
+        e.target.files = null;
+      }}
+    />
+  );
+};
+
+export default InputFileBase;

--- a/packages/react-components-lab/src/components/InputFile/InputFileButton.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFileButton.tsx
@@ -1,0 +1,40 @@
+import { Upload } from '@mui/icons-material';
+import { Button, Stack, Typography } from '@mui/material';
+import React, { FC } from 'react';
+import { InputFileProps, InputVariantProps } from './types';
+import InputFileBase from './InputFileBase';
+
+const InputFileButton: FC<Partial<InputFileProps> & InputVariantProps> = ({
+  accept,
+  quantity,
+  buttonVariant,
+  files,
+  uploadFiles,
+  showFiles,
+  text,
+  icon,
+}) => (
+  <Stack gap={0.5} height={1} width={1}>
+    <Button
+      component="label"
+      startIcon={icon || <Upload />}
+      variant={buttonVariant || 'contained'}
+    >
+      {text || 'Upload'}
+      <InputFileBase
+        accept={accept}
+        handleFileChange={(e) => uploadFiles(e.target.files)}
+        quantity={quantity}
+      />
+    </Button>
+    <Typography variant="caption">
+      {showFiles &&
+        files.length > 0 &&
+        `File${files.length > 1 ? 's' : ''}: ${files
+          .map((file) => file.name)
+          .join(', ')}`}
+    </Typography>
+  </Stack>
+);
+
+export default InputFileButton;

--- a/packages/react-components-lab/src/components/InputFile/InputFileDropzone.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFileDropzone.tsx
@@ -1,0 +1,112 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable react/no-array-index-key  */
+import { Clear, FileUpload } from '@mui/icons-material';
+import { Box, IconButton, Stack, Typography } from '@mui/material';
+import React, { DragEvent, FC, MouseEvent, useState } from 'react';
+import { InputFileProps, InputVariantProps } from './types';
+import styles from './styles';
+import InputFileBase from './InputFileBase';
+
+const InputFileDropzone: FC<Partial<InputFileProps> & InputVariantProps> = ({
+  accept,
+  disabled,
+  quantity,
+  showFiles,
+  uploadFiles,
+  text,
+  icon,
+  files,
+  setFiles,
+}) => {
+  const [dragging, setDragging] = useState(false);
+
+  const prevent = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDragOut = (e: DragEvent<HTMLDivElement>) => {
+    prevent(e);
+
+    if (!disabled) {
+      setDragging(false);
+    }
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    prevent(e);
+
+    if (!disabled) {
+      setDragging(true);
+    } else {
+      // set cursor to no-drop
+      e.dataTransfer.dropEffect = 'none';
+    }
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    prevent(e);
+
+    if (disabled) {
+      return;
+    }
+
+    setDragging(false);
+    uploadFiles(e.dataTransfer.files);
+    e.dataTransfer.clearData();
+  };
+
+  const handleRemoveFile = (i: number) => (e: MouseEvent) => {
+    e.preventDefault();
+    setFiles((prevFiles) => prevFiles.filter((_, index) => index !== i));
+  };
+
+  return (
+    <Box
+      component="label"
+      sx={{
+        ...styles.dropzone,
+        ...(dragging ? styles.dropzoneActive : styles.dropzoneInactive),
+        ...(disabled && styles.disabled),
+      }}
+      onDragEnter={prevent}
+      onDragLeave={handleDragOut}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      <Stack alignItems="center" justifyContent="center">
+        {icon || <FileUpload fontSize="large" />}
+
+        <Typography variant="h3">
+          {dragging
+            ? 'Release to upload'
+            : text || 'Drop a file here to upload'}
+        </Typography>
+        <Box mt={1}>
+          <InputFileBase
+            accept={accept}
+            handleFileChange={(e) => uploadFiles(e.target.files)}
+            quantity={quantity}
+          />
+
+          {showFiles &&
+            files.map((file, i) => (
+              <Stack alignItems="center" direction="row" key={`file-${i}`}>
+                <IconButton
+                  size="small"
+                  sx={{ height: 24, width: 24 }}
+                  disableRipple
+                  onClick={handleRemoveFile(i)}
+                >
+                  <Clear />
+                </IconButton>
+                <Typography key={i}>{file.name}</Typography>
+              </Stack>
+            ))}
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+export default InputFileDropzone;

--- a/packages/react-components-lab/src/components/InputFile/InputFileIconButton.tsx
+++ b/packages/react-components-lab/src/components/InputFile/InputFileIconButton.tsx
@@ -1,0 +1,43 @@
+import { Upload } from '@mui/icons-material';
+import { IconButton, Stack, Typography } from '@mui/material';
+import React, { FC } from 'react';
+import { InputFileProps, InputVariantProps } from './types';
+import InputFileBase from './InputFileBase';
+
+const InputFileIconButton: FC<Partial<InputFileProps> & InputVariantProps> = ({
+  icon,
+  accept,
+  quantity,
+  showFiles,
+  files,
+  uploadFiles,
+}) => (
+  <Stack alignItems="flex-start" gap={0.5} height={1} width={1}>
+    <IconButton
+      component="label"
+      sx={{
+        color: 'white',
+        backgroundColor: 'primary.main',
+        '&:hover': {
+          backgroundColor: 'primary.dark',
+        },
+      }}
+    >
+      {icon || <Upload />}
+      <InputFileBase
+        accept={accept}
+        handleFileChange={(e) => uploadFiles(e.target.files)}
+        quantity={quantity}
+      />
+    </IconButton>
+    <Typography variant="caption">
+      {showFiles &&
+        files.length > 0 &&
+        `File${files.length > 1 ? 's' : ''}: ${files
+          .map((file) => file.name)
+          .join(', ')}`}
+    </Typography>
+  </Stack>
+);
+
+export default InputFileIconButton;

--- a/packages/react-components-lab/src/components/InputFile/styles.ts
+++ b/packages/react-components-lab/src/components/InputFile/styles.ts
@@ -1,0 +1,29 @@
+const styles = {
+  dropzone: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    border: `2px dashed`,
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    cursor: 'pointer',
+  },
+  dropzoneActive: {
+    backgroundColor: 'grey.100',
+    borderColor: 'success.light',
+    border: `4px dashed`,
+  },
+  dropzoneInactive: {
+    backgroundColor: 'grey.50',
+    borderColor: 'grey.700',
+  },
+  disabled: {
+    cursor: 'no-drop',
+    noDrop: 'no-drop',
+    backgroundColor: 'grey.100',
+    opacity: 0.7,
+  },
+};
+
+export default styles;

--- a/packages/react-components-lab/src/components/InputFile/types.ts
+++ b/packages/react-components-lab/src/components/InputFile/types.ts
@@ -1,0 +1,25 @@
+import { ChangeEvent, Dispatch, ReactNode, SetStateAction } from 'react';
+
+export interface InputFileProps {
+  variant: 'dropzone' | 'button' | 'iconbutton';
+  buttonVariant?: 'contained' | 'outlined';
+  quantity?: 'single' | 'multiple';
+  accept?: string | string[];
+  disabled?: boolean;
+  showFiles?: boolean;
+  replaceOnUpload?: boolean;
+  text?: string;
+  icon?: ReactNode;
+  onFilesRejected?: (file: File | File[]) => void;
+  onFilesUploaded?: (file: File | File[]) => void;
+}
+
+export interface InputVariantProps {
+  files: File[];
+  uploadFiles: (files: File[] | FileList) => void;
+  setFiles: Dispatch<SetStateAction<File[]>>;
+}
+
+export interface InputFileBaseProps {
+  handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}

--- a/packages/react-components-lab/src/components/InputFile/util.ts
+++ b/packages/react-components-lab/src/components/InputFile/util.ts
@@ -1,0 +1,49 @@
+const accepts = (file: File, acceptedFiles: string | string[]) => {
+  if (file && acceptedFiles) {
+    const acceptedFilesArray = Array.isArray(acceptedFiles)
+      ? acceptedFiles
+      : acceptedFiles.split(',');
+    const fileName = file.name || '';
+    const mimeType = (file.type || '').toLowerCase();
+    const baseMimeType = mimeType.replace(/\/.*$/, '');
+
+    return acceptedFilesArray.some((type) => {
+      const validType = type.trim().toLowerCase();
+      if (validType.charAt(0) === '.') {
+        return fileName.toLowerCase().endsWith(validType);
+      }
+      if (validType.endsWith('/*')) {
+        // This is something like a image/* mime type
+        return baseMimeType === validType.replace(/\/.*$/, '');
+      }
+      return mimeType === validType;
+    });
+  }
+  return true;
+};
+
+const fileAccepted = (file: File, accept: string | string[]) =>
+  file.type === 'application/x-moz-file' || accepts(file, accept);
+
+const validateFiles = (
+  transferFiles: File[],
+  accept: string | string[] | undefined
+) => {
+  if (!accept) {
+    return [transferFiles, []];
+  }
+
+  const rejectedFiles = [] as File[];
+  let theFiles = transferFiles;
+
+  theFiles.forEach((file) => {
+    if (!fileAccepted(file, accept)) {
+      theFiles = theFiles.filter((f) => file.name !== f.name);
+      rejectedFiles.push(file);
+    }
+  });
+
+  return [theFiles, rejectedFiles];
+};
+
+export { accepts, fileAccepted, validateFiles };

--- a/packages/react-components-lab/src/index.ts
+++ b/packages/react-components-lab/src/index.ts
@@ -38,6 +38,9 @@ export { default as GapBox } from './components/GapBox/GapBox';
 export { default as GapBoxStyled } from './components/GapBox/GapBox.styled';
 export * from './components/GapBox/types';
 
+// InputFile
+export { default as InputFile } from './components/InputFile/InputFile';
+
 // LegendBase
 export { default as LegendBase } from './components/LegendBase/LegendBase';
 export * from './components/LegendBase/types';

--- a/packages/react-components-lab/src/index.ts
+++ b/packages/react-components-lab/src/index.ts
@@ -40,6 +40,7 @@ export * from './components/GapBox/types';
 
 // InputFile
 export { default as InputFile } from './components/InputFile/InputFile';
+export { InputFileProps } from './components/InputFile/types';
 
 // LegendBase
 export { default as LegendBase } from './components/LegendBase/LegendBase';


### PR DESCRIPTION
## This PR

Adds the InputFile component, which supports a dropzone, a button and an icon button. It has a variety of features, such as:

- you can specify `replaceOnUpload` which decides if the uploaded files should be replaced or extended if you upload again
- you can specify `showFiles` if files should be shown or not. for dropzone, if this is enabled (which it is by default), the user will have the ability to remove items as well.
- `quantity`: one or multiple files?
- ... and more 

## Notes

- No notes to add

### Fulfilled the scope of this repo?

- [ ] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [x] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [x] Story included
