### PR TITLE
feat: Scenarios old add group by function as prop

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.48",
+  "version": "0.8.49",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/react-components/src/Scenarios/ScenarioListOLD/ScenarioList.tsx
+++ b/packages/react-components/src/Scenarios/ScenarioListOLD/ScenarioList.tsx
@@ -25,6 +25,7 @@ const ScenarioListOLD = (props: ScenarioListOLDProps) => {
     nameField,
     timeZone,
     statusOverrideFunction,
+    groupByItemFunction,
   } = props;
   const [groupedScenarios, setGroupedScenarios] = useState<Dictionary<ScenarioOLD[]>>();
   const [selectedId, setSelectedId] = useState(selectedScenarioId);
@@ -42,9 +43,11 @@ const ScenarioListOLD = (props: ScenarioListOLDProps) => {
     setGroupedScenarios(
       showHour || showDate
         ? groupBy(scenarios, (scenario) => {
-            return scenario.dateTime && timeZone
-              ? format(utcToTz(scenario.dateTime, timeZone), 'yyyy-MM-dd')
-              : format(parseISO(scenario.dateTime), 'yyyy-MM-dd') || '';
+          return groupByItemFunction ?
+          groupByItemFunction(scenario, timeZone) : 
+          scenario.dateTime && timeZone
+            ? format(utcToTz(scenario.dateTime, timeZone), 'yyyy-MM-dd')
+            : format(parseISO(scenario.dateTime), 'yyyy-MM-dd') || '';
           })
         : groupBy(scenarios, (scenario) => scenario.dateTime),
     );

--- a/packages/react-components/src/Scenarios/ScenarioListOLD/types.ts
+++ b/packages/react-components/src/Scenarios/ScenarioListOLD/types.ts
@@ -65,6 +65,10 @@ interface ScenarioListOLDProps {
    * The function that returns the new status to override
    */
   statusOverrideFunction?: (scenario: Scenario) => StatusOverride;
+  /**
+   * The function that returns the item to be used for grouping by:
+   */
+  groupByItemFunction?: (scenario: Scenario, timeZone?: string) => string;
 }
 
 export default ScenarioListOLDProps;

--- a/packages/react-components/src/Scenarios/ScenariosOLD/Scenarios.tsx
+++ b/packages/react-components/src/Scenarios/ScenariosOLD/Scenarios.tsx
@@ -50,6 +50,7 @@ const ScenariosOLD = (props: ScenariosOLDProps) => {
     translations,
     timeZone,
     statusOverrideFunction,
+    groupByItemFunction,
   } = props;
 
   const [dialog, setDialog] = useState<GeneralDialogProps>();
@@ -419,6 +420,7 @@ const ScenariosOLD = (props: ScenariosOLDProps) => {
         status={status}
         timeZone={timeZone}
         statusOverrideFunction={statusOverrideFunction}
+        groupByItemFunction={groupByItemFunction}
       />
     );
   }

--- a/packages/react-components/src/Scenarios/ScenariosOLD/types.ts
+++ b/packages/react-components/src/Scenarios/ScenariosOLD/types.ts
@@ -153,6 +153,11 @@ interface ScenariosOLDProps {
    * The function that returns the new status to override
    */
   statusOverrideFunction?: (scenario: Scenario) => StatusOverride | {};
+
+  /**
+   * The function that returns the item to be used for grouping by:
+   */
+  groupByItemFunction?: (scenario: Scenario, timeZone?: string) => string;
 }
 
 interface dataFilterbyPropertyObj {


### PR DESCRIPTION
## This PR

Closes #xxx

## Notes

Adds functionality to allow for a custom grouping by functionality instead of only by dateTime on the scenariosOLD component. 

This grouping by function is added in as an optional prop by users of the component. If no prop is added it will group by dateTime.

### Fulfilled the scope of this repo?

- [x] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [x] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
