### PR TITLE
feat/scenarios old fetch scenarios by query with filter

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.48",
+  "version": "0.8.50",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/react-components/src/Scenarios/ScenariosOLD/Scenarios.tsx
+++ b/packages/react-components/src/Scenarios/ScenariosOLD/Scenarios.tsx
@@ -10,7 +10,7 @@ import {
   postScenario,
   updateScenario,
 } from '../../api';
-import { JobParameters } from '../../api/types';
+import { JobParameters, QueryFilter } from '../../api/types';
 import GeneralDialog from '../../common/GeneralDialog/GeneralDialog';
 import GeneralDialogProps from '../../common/GeneralDialog/types';
 import { checkConditions, getObjectProperty, setObjectProperty } from '../../utils/Utils';
@@ -18,6 +18,7 @@ import { ScenarioListOLD } from '../ScenarioListOLD/ScenarioList';
 import { MenuItem, QueryDates, ScenarioOLD } from '../types';
 import ScenariosOLDProps from './types';
 import useStyles from './useStyles';
+import { fetchScenariosPost } from '../../api/Scenarios/ScenariosApi';
 
 const ScenariosOLD = (props: ScenariosOLDProps) => {
   const {
@@ -41,6 +42,7 @@ const ScenariosOLD = (props: ScenariosOLDProps) => {
     showStatus,
     status,
     queryDates,
+    queryFilter,
     frequency = 10,
     onContextMenuClick,
     onScenarioSelected,
@@ -61,10 +63,10 @@ const ScenariosOLD = (props: ScenariosOLDProps) => {
   useEffect(() => {
     let interval: ReturnType<typeof setTimeout>;
 
-    if (queryDates) {
-      fetchScenariosByDateList(queryDates);
+    if (queryDates || queryFilter) {
+      fetchScenariosByQuery(queryDates, queryFilter);
 
-      interval = setInterval(() => fetchScenariosByDateList(queryDates), frequency * 1000);
+      interval = setInterval(() => fetchScenariosByQuery(queryDates, queryFilter), frequency * 1000);
     } else {
       fetchScenariosList();
 
@@ -98,18 +100,58 @@ const ScenariosOLD = (props: ScenariosOLDProps) => {
     }
   }, [addScenario]);
 
-  const fetchScenariosByDateList = (queryDates: QueryDates) => {
+  const fetchScenariosByQuery = (queryDates: QueryDates, queryFilter?: QueryFilter[]) => {
+    const dataSelectors = [
+      nameField,
+      ...descriptionFields!.map((descriptionField) => descriptionField.field),
+      ...extraFields!.map((descriptionField) => descriptionField.field),
+    ];
+    if (queryFilter) {
+      fetchScenariosByQueryFilter(queryFilter, dataSelectors);    
+    } else {
+      fetchScenariosByDateList(queryDates, dataSelectors);    
+    }
+  }
+
+  const fetchScenariosByQueryFilter = (queryFilter: QueryFilter[], dataSelectors: any[]) => {
+    fetchScenariosPost(
+      {
+        host,
+        connection: scenarioConnection,
+        dataSelectors,
+        queryFilter,
+      },
+      token,
+    ).subscribe(
+      (res) => {
+        const rawScenarios = res.map((s: { data: string }) => {
+          s.data = s.data ? JSON.parse(s.data) : s.data;
+
+          return s;
+        });
+
+        const newScenarios = rawScenarios.filter((scenario) => checkConditions(scenario, dataFilterbyProperty));
+
+        setScenarios(newScenarios);
+
+        if (onScenariosReceived) {
+          onScenariosReceived(newScenarios);
+        }
+      },
+      (error) => {
+        console.log(error);
+      },
+    );
+  }
+
+  const fetchScenariosByDateList = (queryDates: QueryDates, dataSelectors: any[]) => {        
     fetchScenariosByDate(
       {
         host,
         connection: scenarioConnection,
         from: queryDates.from,
         to: queryDates.to,
-        dataSelectors: [
-          nameField,
-          ...descriptionFields!.map((descriptionField) => descriptionField.field),
-          ...extraFields!.map((descriptionField) => descriptionField.field),
-        ],
+        dataSelectors,
       },
       token,
     ).subscribe(

--- a/packages/react-components/src/Scenarios/ScenariosOLD/types.ts
+++ b/packages/react-components/src/Scenarios/ScenariosOLD/types.ts
@@ -1,4 +1,4 @@
-import { JobParameters } from '../../api/types';
+import { JobParameters, QueryFilter } from '../../api/types';
 import { DescriptionField, MenuItem, QueryDates, Scenario, Status, StatusOverride } from '../types';
 
 interface ScenariosOLDProps {
@@ -72,6 +72,10 @@ interface ScenariosOLDProps {
    * Value range to fetch scenario by date
    */
   queryDates?: QueryDates;
+  /**
+   * Query filters to use when fetching the scenarios data.
+   */
+  queryFilter?: QueryFilter[];
   /**
    * Customising translation dialog
    */

--- a/packages/react-components/src/api/Scenarios/ScenariosApi.ts
+++ b/packages/react-components/src/api/Scenarios/ScenariosApi.ts
@@ -1,6 +1,5 @@
 import { tap } from 'rxjs/operators';
 import { DataSource } from '../../api/types';
-import { ScenarioItem } from '../../Scenarios/ScenarioItem/ScenarioItem';
 import { fetchUrl } from '../helpers';
 
 /**
@@ -37,6 +36,30 @@ const fetchScenarios = (dataSource: DataSource, token: string) => {
     additionalHeaders: {
       Authorization: `Bearer ${token}`,
     },
+  });
+};
+
+/**
+ * /api/scenarios/{connectionId}/query
+ * Gets all scenarios that match the given filtering criteria:
+ * @param dataSource
+ * @param filtering
+ * @param token
+ */
+const fetchScenariosPost = (dataSource: DataSource, token: string) => {
+  const dataSelectors =
+    dataSource.dataSelectors && dataSource.dataSelectors.length > 0
+      ? `?dataSelectors=[${dataSource.dataSelectors
+          .map((dataSelector) => dataSelector.replace('data.', ''))
+          .join(',')}]`
+      : '';
+
+  return fetchUrl(`${dataSource.host}/api/scenarios/${dataSource.connection}/query${dataSelectors}`, {
+    method: 'Post',
+    additionalHeaders: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(dataSource?.queryFilter),
   });
 };
 
@@ -126,4 +149,4 @@ const updateScenario = (dataSource: DataSource, token: string, scenario: any) =>
     body: JSON.stringify(scenario),
   });
 
-export { fetchScenario, fetchScenarios, fetchScenariosByDate, deleteScenario, postScenario, updateScenario };
+export { fetchScenario, fetchScenarios, fetchScenariosPost, fetchScenariosByDate, deleteScenario, postScenario, updateScenario };

--- a/packages/react-components/src/api/types.ts
+++ b/packages/react-components/src/api/types.ts
@@ -25,6 +25,10 @@ interface DataSource {
    * Format: new Date();
    */
   to?: string;
+  /**
+   * Query filters to apply to the request.
+   */
+  queryFilter?: QueryFilter[];
   sheetName?: string;
   tokenJobLog?: string;
   hostJobLog?: string;
@@ -71,4 +75,12 @@ interface JobParameters {
   [key: string]: string | string[];
 }
 
-export { Options, DataSource, Header, JobQuery, JobParameters, User };
+
+interface QueryFilter {
+  item: string;
+  queryOperator: string;
+  value: string;
+  negation?: boolean;
+}
+
+export { Options, DataSource, Header, JobQuery, JobParameters, User, QueryFilter };


### PR DESCRIPTION
## This PR

Adds a prop to scenarios old allowing to add a custom filter to fetch scenarios by. 

Adds the scenarios post method for fetching scenarios, this allows finer filtering as the filter is part of the post and not just limited to dateTime.

Closes #xxx

## Notes

- No notes to add

### Fulfilled the scope of this repo?

- [x ] The same functionality of the component can not be achieved with theming, basic styling or composition of existing components
- [x ] The component implements an element of the [DHI Design Guidelines](https://www.figma.com/file/pSfX5GNsa6xhKGbi3DWQtn/DHI-Official-Guidelines) or is otherwise generic enough in functionality and close enough to the DHI CVI that it is likely to find reuse in other projects

### Completness

- [ ] Story included
